### PR TITLE
Integrate Career Level Shortname and matching lists

### DIFF
--- a/src/Application/People/Queries/GetPeopleWithBasicInfo/GetPeopleQuery.cs
+++ b/src/Application/People/Queries/GetPeopleWithBasicInfo/GetPeopleQuery.cs
@@ -35,7 +35,7 @@ namespace MemberManager.Application.People.Queries.GetPeopleWithBasicInfo
                     FistName = person.FirstName,
                     Surname = person.Surname,
                     CurrentCareerLevel = person.PersonCareerLevels
-                        .Where(cl => cl.EndDateTime == null).Select(pc => pc.CareerLevel.Name).FirstOrDefault(),
+                        .Where(cl => cl.EndDateTime == null).Select(pc => pc.CareerLevel.ShortName).FirstOrDefault(),
                     CurrentMemberStatus = person.PersonMemberStatus
                         .Where(cl => cl.EndDateTime == null).Select(pm => pm.MemberStatus.Name).FirstOrDefault(),
                     CurrentPositions = person.PersonPositions

--- a/src/WebUI/ClientApp/src/app/modules/career-level/career-level-list/career-level-list.component.html
+++ b/src/WebUI/ClientApp/src/app/modules/career-level/career-level-list/career-level-list.component.html
@@ -5,9 +5,14 @@
           <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
           <td mat-cell *matCellDef="let element">{{ element.name }}</td>
         </ng-container>
+
+        <ng-container matColumnDef="shortName">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Kürzel</th>
+          <td mat-cell *matCellDef="let element">{{ element.shortName }}</td>
+        </ng-container>
   
         <ng-container matColumnDef="countAssignees">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Assignees</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header># Zugewiesen</th>
           <td mat-cell *matCellDef="let element">{{ element.countAssignees }}</td>
         </ng-container>
       </data-table>

--- a/src/WebUI/ClientApp/src/app/modules/career-level/career-level-list/career-level-list.component.ts
+++ b/src/WebUI/ClientApp/src/app/modules/career-level/career-level-list/career-level-list.component.ts
@@ -36,7 +36,7 @@ export class CareerLevelListComponent implements AfterViewInit {
 
   careerLevels: CareerLevelLookupDto[];
   dataSource: MatTableDataSource<CareerLevelLookupDto>;
-  columns: string[] = ["name", "countAssignees"];
+  columns: string[] = ["name","shortName", "countAssignees"];
 
   selected: MemberStatusLookupDto;
 

--- a/src/WebUI/ClientApp/src/app/modules/member-status/components/member-status-list/member-status-list.component.html
+++ b/src/WebUI/ClientApp/src/app/modules/member-status/components/member-status-list/member-status-list.component.html
@@ -7,7 +7,7 @@
       </ng-container>
 
       <ng-container matColumnDef="countAssignees">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Assignees</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header># Zugewiesen</th>
         <td mat-cell *matCellDef="let element">{{ element.countAssignees }}</td>
       </ng-container>
     </data-table>

--- a/src/WebUI/ClientApp/src/app/modules/position/components/position-list/position-list.component.html
+++ b/src/WebUI/ClientApp/src/app/modules/position/components/position-list/position-list.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="dataSource">
     <data-table #dataTable [dataSource]="dataSource" [columns]="columns" (onSelectEvent)="onSelect($event)" (onAddClickedEvent)="onCreate()" matSort>
       <ng-container matColumnDef="shortName">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Short name</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Kürzel</th>
         <td mat-cell *matCellDef="let element">{{ element.shortName }}</td>
       </ng-container>
 
@@ -12,12 +12,12 @@
       </ng-container>
 
       <ng-container matColumnDef="isActive">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>is active?</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Aktiv?</th>
         <td mat-cell *matCellDef="let element">{{ element.isActive }}</td>
       </ng-container>
 
       <ng-container matColumnDef="countAssignees">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Assignees</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header># Zugewiesen</th>
         <td mat-cell *matCellDef="let element">{{ element.countAssignees }}</td>
       </ng-container>
     </data-table>


### PR DESCRIPTION
Macthed the List, by using same wording 
- Assignes -> # Zugewiesene
- short name -> Kürzel

and added the careerlevel shortname in careerLevel list where it was missing and added it to memberList as requested in #48 